### PR TITLE
Added vercel.json to fix the route issue

### DIFF
--- a/ApothecaryShopUI/vercel.json
+++ b/ApothecaryShopUI/vercel.json
@@ -1,0 +1,10 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}
+
+


### PR DESCRIPTION
closes  #34 :- Hey @mohitahlawat2001 , this change introduces a vercel.json configuration file to resolve persistent 404 "Not Found" errors on all client-side routes when the application is deployed on Vercel.
The application is a Single Page Application (SPA) built with React, which uses client-side routing to handle navigation. When a user navigated to a path like /login, the backend would redirect, but the Vercel server was attempting to find a corresponding static file (like /login/index.html) on the server.
Since the app serves all content from a single index.html file, the server couldn't find the requested path and returned a 404 error. This broke navigation for users who refreshed the page or accessed a direct link.

To fix this, I created a vercel.json file at the root of the project with the following rewrite rule:
{
  "rewrites": [
    {
      "source": "/(.*)",
      "destination": "/index.html"
    }
  ]
}

This configuration tells the Vercel server to intercept all incoming requests ("source": "/(.*)") and serve the index.html file ("destination": "/index.html") instead of trying to find a file that matches the URL path.

Once index.html is loaded, the React application starts, and its client-side router (like React Router) reads the URL from the browser and renders the correct component. This ensures our app handles all routing as intended.

Please let me know if this fixes the issue or do we need to try something else as it is not replicated in local.
Thank you